### PR TITLE
Small typo in `basic_usage.md`, convert relative links

### DIFF
--- a/book/src/api_documentation.md
+++ b/book/src/api_documentation.md
@@ -2,5 +2,5 @@
 
 The latest API documentation is available [here] or at [docs.rs].
 
-[here]: ../doc/float_eq/index.html
+[here]: ../doc/float_eq/index.md
 [docs.rs]: https://docs.rs/float_eq/

--- a/book/src/how_to/compare_custom_types.md
+++ b/book/src/how_to/compare_custom_types.md
@@ -10,5 +10,5 @@ derive the traits].
 2) If your type cannot have the traits derived for it, of if you do not wish to
 enable the "derive" feature, see [How to manually implement the traits].
 
-[How to derive the traits]: ./derive_the_traits.html
-[How to manually implement the traits]: ./manually_implement_the_traits.html
+[How to derive the traits]: ./derive_the_traits.md
+[How to manually implement the traits]: ./manually_implement_the_traits.md

--- a/book/src/how_to/derive_the_traits.md
+++ b/book/src/how_to/derive_the_traits.md
@@ -154,5 +154,5 @@ optionally use [AssertFloatEqAll].
 [FloatEqAll]: ../../doc/float_eq/trait.FloatEqAll.html
 [FloatEqDebugUlpsDiff]: ../../doc/float_eq/trait.FloatEqDebugUlpsDiff.html
 [FloatEqUlpsTol]: ../../doc/float_eq/trait.FloatEqUlpsTol.html
-[How to manually implement the traits]: ./manually_implement_the_traits.html
-[ULPs]: ../background/float_comparison_algorithms.html#units-in-the-last-place-ulps-comparison
+[How to manually implement the traits]: ./manually_implement_the_traits.md
+[ULPs]: ../background/float_comparison_algorithms.md#units-in-the-last-place-ulps-comparison

--- a/book/src/how_to/manually_implement_the_traits.md
+++ b/book/src/how_to/manually_implement_the_traits.md
@@ -327,4 +327,4 @@ impl AssertFloatEqAll for Point {
 [FloatEqDebugUlpsDiff]: ../../doc/float_eq/trait.FloatEqDebugUlpsDiff.html
 [FloatEqUlpsTol]: ../../doc/float_eq/trait.FloatEqUlpsTol.html
 [UlpsTol]: ../../doc/float_eq/type.UlpsTol.html
-[How to derive the traits]: ./derive_the_traits.html
+[How to derive the traits]: ./derive_the_traits.md

--- a/book/src/tutorials/basic_usage.md
+++ b/book/src/tutorials/basic_usage.md
@@ -286,7 +286,7 @@ determine the absolute distance between numbers in those ranges:
 
 This is why our addition was unexpectedly rounded up:
 
-- `0.1` is in the range 0.0625 to 0.125, which are all `0.0625 f64::EPSILON` apart.
+- `0.1` is in the range 0.0625 to 0.125, which are all `0.0625 * f64::EPSILON` apart.
 - `0.2` is in the range 0.125 to 0.25, which are all `0.125 * f64::EPSILON` apart.
 - `0.1 + 0.2` is in the range 0.25 to 0.5, which are all `0.25 * f64::EPSILON` apart.
 
@@ -585,7 +585,7 @@ toward zero are available.
 most n representable values apart", for example you might use a tolerance of
 `4.0 * f64::EPSILON`.
 
-[absolute tolerance comparison]: ../background/float_comparison_algorithms.html#absolute-tolerance-comparison
+[absolute tolerance comparison]: ../background/float_comparison_algorithms.md#absolute-tolerance-comparison
 [API documentation]: ../api_documentation.md
 [background]: ../background.md
 [catastrophic cancellation]: https://en.wikipedia.org/wiki/Catastrophic_cancellation
@@ -595,12 +595,12 @@ most n representable values apart", for example you might use a tolerance of
 [Numerical Analysis]: https://en.wikipedia.org/wiki/Numerical_analysis
 [numerically unstable]: https://nhigham.com/2020/08/04/what-is-numerical-stability/
 [old classic]: https://0.30000000000000004.com/
-[relative tolerance comparison]: ../background/float_comparison_algorithms.html#relative-tolerance-comparison
+[relative tolerance comparison]: ../background/float_comparison_algorithms.md#relative-tolerance-comparison
 [represented exactly]: https://www.exploringbinary.com/why-0-point-1-does-not-exist-in-floating-point/
 [roundoff error]: https://en.wikipedia.org/wiki/Round-off_error
 [specific tasks]: ../how_to.md
 [truncation error]: https://en.wikipedia.org/wiki/Truncation_error
-[ULPs comparison]: ../background/float_comparison_algorithms.html#units-in-the-last-place-ulps-comparison
+[ULPs comparison]: ../background/float_comparison_algorithms.md#units-in-the-last-place-ulps-comparison
 [underlying representation]: https://randomascii.wordpress.com/2012/01/23/stupid-float-tricks-2/
 [`assert_float_eq!`]: ../../doc/float_eq/macro.assert_float_eq.html
 [`float_eq!`]: ../../doc/float_eq/macro.float_eq.html


### PR DESCRIPTION
Hello 👋

I'm primarily submitting a small typo fix in `basic_usage.md`. 

I was also reading the bare files in the repo and many of the relative links were broken due to the relative `*.html` links. I changed them to be primarily `*.md` links, which work when browsing the bare repo and will compile into correct html links when the book is built. Mdbook suggests relative `*.md*` links in their docs here: https://rust-lang.github.io/mdBook/format/markdown.html?highlight=link#links .I didn't touch any of the `/docs/` links, since those aren't present in the repo before the build. 

I tested each of my changes locally using the included `./docs_build.bat` file and the links all routed correctly.

p.s. Thanks for this crate and it's wonderful documentation. I've really enjoyed reading through everything!